### PR TITLE
회원정보 삭제 기능 추가

### DIFF
--- a/mini-project/src/main/java/com/fast/miniproject/auth/controller/AuthController.java
+++ b/mini-project/src/main/java/com/fast/miniproject/auth/controller/AuthController.java
@@ -44,6 +44,11 @@ public class AuthController {
         return userService.updateUser(loginReqDTO,patchUserReqDTO);
     }
 
+    @DeleteMapping("/api/user/delete")
+    public ResponseDTO<?> deleteUser(@AuthenticationPrincipal LoginReqDTO loginReqDTO, String password) {
+        return userService.deleteUser(loginReqDTO,password);
+    }
+
     @GetMapping("/hello")
     @PreAuthorize("hasAnyRole('USER')") // USER 권한만 호출 가능
     public String hello(@AuthenticationPrincipal LoginReqDTO loginReqDTO) {

--- a/mini-project/src/main/java/com/fast/miniproject/auth/entity/User.java
+++ b/mini-project/src/main/java/com/fast/miniproject/auth/entity/User.java
@@ -66,4 +66,9 @@ public class User {
         this.salary = salary;
         this.job = job;
     }
+
+    public void delete(String withdraw) {
+        this.deleteCheck = withdraw;
+    }
+
 }

--- a/mini-project/src/main/java/com/fast/miniproject/auth/service/UserService.java
+++ b/mini-project/src/main/java/com/fast/miniproject/auth/service/UserService.java
@@ -11,4 +11,5 @@ public interface UserService {
     ResponseDTO<?> login(LoginReqDTO loginReqDTO);
     public ResponseDTO<?> editUser(LoginReqDTO loginReqDTO) ;
     public ResponseDTO<?> updateUser(LoginReqDTO loginReqDTO, PatchUserReqDTO patchUserReqDTO);
+    public ResponseDTO<?> deleteUser(LoginReqDTO loginReqDTO, String password);
 }


### PR DESCRIPTION
## Description
회원정보가 삭제되면 해당 회원의 deleteCheck 컬럼에 withdraw 를 입력하는 방식으로 처리.
로그인시 deleteCheck안에 내용이 비어있다면 로그인 가능 하게 구현.

## Key Changes

#12  참조.

## To Reviewers


